### PR TITLE
Allow configurable separator

### DIFF
--- a/influx2otel/metrics.go
+++ b/influx2otel/metrics.go
@@ -228,7 +228,7 @@ func (b *MetricsBatch) addPointWithUnknownSchema(measurement string, tags map[st
 			continue
 		}
 
-		metricName := fmt.Sprintf("%s_%s", measurement, k)
+		metricName := fmt.Sprintf("%s%s%s", measurement, b.separator, k)
 		metric, attributes, err := b.lookupMetric(metricName, tags, common.InfluxMetricValueTypeGauge)
 		if err != nil {
 			return err

--- a/influx2otel/metrics_telegraf_prometheus_v1.go
+++ b/influx2otel/metrics_telegraf_prometheus_v1.go
@@ -114,7 +114,7 @@ func (b *MetricsBatch) convertGaugeV1(measurement string, tags map[string]string
 			continue
 		}
 
-		metricName := fmt.Sprintf("%s_%s", measurement, k)
+		metricName := fmt.Sprintf("%s%s%s", measurement, b.separator, k)
 		metric, attributes, err := b.lookupMetric(metricName, tags, common.InfluxMetricValueTypeGauge)
 		if err != nil {
 			return err
@@ -184,7 +184,7 @@ func (b *MetricsBatch) convertSumV1(measurement string, tags map[string]string, 
 			continue
 		}
 
-		metricName := fmt.Sprintf("%s_%s", measurement, k)
+		metricName := fmt.Sprintf("%s%s%s", measurement, b.separator, k)
 		metric, attributes, err := b.lookupMetric(metricName, tags, common.InfluxMetricValueTypeSum)
 		if err != nil {
 			return err

--- a/influx2otel/options.go
+++ b/influx2otel/options.go
@@ -1,0 +1,17 @@
+package influx2otel
+
+import "github.com/influxdata/influxdb-observability/common"
+
+type Option func(*LineProtocolToOtelMetrics)
+
+func WithLogger(l common.Logger) Option {
+	return func(lo *LineProtocolToOtelMetrics) {
+		lo.logger = l
+	}
+}
+
+func WithSeparator(s string) Option {
+	return func(lo *LineProtocolToOtelMetrics) {
+		lo.separator = s
+	}
+}


### PR DESCRIPTION
Currently the metric names generated for OpenTelemetry output always take the form `measurement_field`. This code extends the interface of the influx2otel converter, by making separator a field of the `LineProtocolToOtelMetrics` type. The previous functions should work as expected, by automatically constructing the type with `"_"` as the value of the separator field. Client code may now use a new constructor for the `*LineProtocolToOtelMetrics` type which accepts a variadic functional Option to set fields.